### PR TITLE
docs: add CONSUMER_CONTEXT.md for xq-context-hub

### DIFF
--- a/CONSUMER_CONTEXT.md
+++ b/CONSUMER_CONTEXT.md
@@ -1,0 +1,54 @@
+# Consumer context — xq-plugins
+
+Hub-facing context for agents working from
+[`xq-context-hub`](https://github.com/chauhaidang/xq-context-hub).
+
+## Identity
+
+| Field | Value |
+| --- | --- |
+| Repo | `xq-plugins` |
+| Org | `chauhaidang` |
+| Domain | `platform` |
+| Default branch | `main` |
+| Hub catalogue | `xq-context-hub` `org/catalogue.md` |
+
+## Purpose
+
+Plugins and platform dependencies
+
+## Boundary
+
+**Owns:**
+
+- Responsibilities described by the purpose above (see also hub domain
+  `domains/platform/CONTEXT.md`)
+
+**Does not own:**
+
+- Org-wide conventions (see hub `org/conventions.md`)
+- Other product repos’ implementation details
+
+## Stack
+
+- See this repository’s README and package manifests after checkout
+- Published packages (if any) use the `@chauhaidang` GitHub Packages scope
+
+## Agent entry
+
+- Prefer this file for hub consumers
+- Local agent instructions: `AGENTS.md` when present
+- Domain glossary (hub): `xq-context-hub/domains/platform/CONTEXT.md`
+- Org conventions (hub): `xq-context-hub/org/conventions.md`
+
+## Verification
+
+Run the verification commands documented in this repo’s README / `AGENTS.md`
+before claiming done. If none exist yet, run the minimal smoke checks available
+(`npm test`, `make test`, or language-equivalent) and report gaps.
+
+## Hub pointer
+
+Multi-repo plans and fan-out are orchestrated from
+https://github.com/chauhaidang/xq-context-hub
+(`CONTEXT-MAP.md` → `domains/platform/CONTEXT.md` → this checkout).


### PR DESCRIPTION
## Summary
- Add `CONSUMER_CONTEXT.md` so [`xq-context-hub`](https://github.com/chauhaidang/xq-context-hub) can load hub-facing context for this repo after checkout.

## Test plan
- [ ] File present at repo root on this branch
- [ ] Purpose / domain match this repository